### PR TITLE
Add a basic body type and a demo of its use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nstc"
+version = "0.1.0"
+authors = ["Alex Konradi <alexkonradi@gmail.com>"]
+
+[dependencies]
+nalgebra = "0.16"
+ncollide3d = "0.17"
+nphysics3d = "0.9"
+nphysics_testbed3d = "0.2"
+
+
+[[bin]]
+name = "nstc-view"
+path = "src/view/view.rs"
+
+[lib]
+name = "nstc"
+path = "src/lib.rs"

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -3,24 +3,36 @@ use ncollide3d::shape::{Cuboid, ShapeHandle};
 use nphysics3d::math::AngularVector;
 use std::fmt;
 
+/// An axial joint used to connect two body parts.
 #[derive(Debug)]
 pub struct Joint<N: Real> {
+    /// The maximum angle allowed by the joint, in radians.
     max_angle_rad: N,
+    /// The minimum angle allowed by the joint, in radians.
     min_angle_rad: N,
+    /// The angle of the axis of the joint.
     axis: Unit<AngularVector<N>>,
+    /// The position on the parent at which the joint attaches.
+    ///
+    /// The attachment point on the parent goemetry is the furthest-most projection of this vector
+    /// from the center of the body.
     parent_attachment: Unit<AngularVector<N>>,
 
+    /// The requested velocity of the joint, or None to allow free rotation.
     angular_velocity: Option<N>,
 }
 
 #[derive(Debug)]
 pub struct BodyPartChild<N: Real> {
+    /// The joint conecting this body part to its parent.
     pub joint: Joint<N>,
     pub part: BodyPart<N>,
 }
 
 pub struct BodyPart<N: Real> {
+    /// The physical shape of this body part.
     pub geometry: ShapeHandle<N>,
+    /// The child body parts of this one.
     pub children: Vec<BodyPartChild<N>>,
 }
 
@@ -37,23 +49,37 @@ impl<N: Real> fmt::Debug for BodyPart<N> {
     }
 }
 
+/// The body of an `Actor` impl.
 #[derive(Debug)]
 pub struct Body<N: Real> {
+    /// The parts of the body.
+    ///
+    /// The body is represented as a tree of parts from parent to children.
     pub tree: BodyPart<N>,
 }
 
 pub trait Actor<N: Real> {
+    /// Returns the representation of this actor's body.
+    ///
+    /// The body can change as the actor updates joint velocities. This provides a read-only view
+    /// for observers.
     fn body(&self) -> &Body<N>;
 
+    /// Updates the joint velocities for the given timestep.
+    ///
+    /// This should be called by the simulation environment with strictly monotonically increasing
+    /// values of `time`.
     fn step(&mut self, time: N);
 }
 
+/// A dead simple Actor impl that doesn't do anything.
 #[derive(Debug)]
 pub struct BlockBody<N: Real> {
     body_: Body<N>,
 }
 
 impl<N: Real> BlockBody<N> {
+    /// Creates a new `BlockBody` with the given dimensions.
     pub fn new(size: Vector3<N>) -> Self {
         BlockBody {
             body_: Body {

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,0 +1,75 @@
+use nalgebra::{Real, Unit, Vector3};
+use ncollide3d::shape::{Cuboid, ShapeHandle};
+use nphysics3d::math::AngularVector;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct Joint<N: Real> {
+    max_angle_rad: N,
+    min_angle_rad: N,
+    axis: Unit<AngularVector<N>>,
+    parent_attachment: Unit<AngularVector<N>>,
+
+    angular_velocity: Option<N>,
+}
+
+#[derive(Debug)]
+pub struct BodyPartChild<N: Real> {
+    pub joint: Joint<N>,
+    pub part: BodyPart<N>,
+}
+
+pub struct BodyPart<N: Real> {
+    pub geometry: ShapeHandle<N>,
+    pub children: Vec<BodyPartChild<N>>,
+}
+
+impl<N: Real> fmt::Debug for BodyPart<N> {
+    fn fmt<'a>(&self, f: &mut fmt::Formatter<'a>) -> fmt::Result {
+        write!(f, "geometry: ");
+        let s = &self.geometry;
+        if let Some(ref cube) = s.as_shape::<Cuboid<N>>() {
+            write!(f, "{:?}", cube);
+        } else {
+            write!(f, "unknown shape");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct Body<N: Real> {
+    pub tree: BodyPart<N>,
+}
+
+pub trait Actor<N: Real> {
+    fn body(&self) -> &Body<N>;
+
+    fn step(&mut self, time: N);
+}
+
+#[derive(Debug)]
+pub struct BlockBody<N: Real> {
+    body_: Body<N>,
+}
+
+impl<N: Real> BlockBody<N> {
+    pub fn new(size: Vector3<N>) -> Self {
+        BlockBody {
+            body_: Body {
+                tree: BodyPart {
+                    geometry: ShapeHandle::new(Cuboid::new(size / (N::one() + N::one()))),
+                    children: vec![],
+                },
+            },
+        }
+    }
+}
+
+impl<N: Real> Actor<N> for BlockBody<N> {
+    fn body(&self) -> &Body<N> {
+        &self.body_
+    }
+
+    fn step(&mut self, _time: N) {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+extern crate nalgebra;
+extern crate ncollide3d;
+extern crate nphysics3d;
+extern crate nphysics_testbed3d;
+
+pub mod actor;
+pub mod simulate;

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -1,0 +1,36 @@
+use nalgebra::{Isometry3, Real};
+use nphysics3d::object::Material;
+use nphysics3d::volumetric::Volumetric;
+use nphysics3d::world::World;
+
+fn add_body_part<N: Real>(
+    part: &super::actor::BodyPart<N>,
+    world: &mut World<N>,
+    collider_margin: N,
+) {
+    let geom = &part.geometry;
+    let inertia = geom.inertia(N::one());
+    let center_of_mass = geom.center_of_mass();
+
+    // TODO fix this
+    let zero = ::nalgebra::zero();
+    let pos = Isometry3::new(zero, zero);
+    let handle = world.add_rigid_body(pos, inertia, center_of_mass);
+
+    world.add_collider(
+        collider_margin,
+        geom.clone(),
+        handle,
+        Isometry3::identity(),
+        Material::default(),
+    );
+
+    for _child in part.children.iter() {
+        panic!("children not supported");
+    }
+}
+
+pub fn build_body<N: Real>(body: &super::actor::Body<N>, world: &mut World<N>, collider_margin: N) {
+    print!("Building body {:?}", body);
+    add_body_part(&body.tree, world, collider_margin)
+}

--- a/src/view/view.rs
+++ b/src/view/view.rs
@@ -1,0 +1,52 @@
+extern crate nalgebra as nalgebra;
+extern crate ncollide3d;
+extern crate nphysics3d;
+extern crate nphysics_testbed3d;
+extern crate nstc;
+
+use nalgebra::{Isometry3, Point3, Vector3};
+use ncollide3d::shape::{Cuboid, ShapeHandle};
+use nphysics3d::object::{BodyHandle, Material};
+use nphysics3d::world::World;
+use nphysics_testbed3d::Testbed;
+use nstc::actor::Actor;
+
+const COLLIDER_MARGIN: f32 = 0.01;
+
+fn main() {
+    /*
+     * World
+     */
+    let mut world = World::new();
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
+
+    /*
+     * Ground.
+     */
+    let ground_size = 50.0;
+    let ground_shape =
+        ShapeHandle::new(Cuboid::new(Vector3::repeat(ground_size - COLLIDER_MARGIN)));
+    let ground_pos = Isometry3::new(Vector3::y() * -ground_size, nalgebra::zero());
+
+    world.add_collider(
+        COLLIDER_MARGIN,
+        ground_shape,
+        BodyHandle::ground(),
+        ground_pos,
+        Material::default(),
+    );
+
+    /*
+     * Create a simple actor
+     */
+    let actor = nstc::actor::BlockBody::new(Vector3::new(5.0, 1.0, 2.0));
+    nstc::simulate::build_body(actor.body(), &mut world, COLLIDER_MARGIN);
+
+    /*
+     * Set up the testbed.
+     */
+    let mut testbed = Testbed::new(world);
+    // testbed.hide_performance_counters();
+    testbed.look_at(Point3::new(-4.0, 1.0, -4.0), Point3::new(0.0, 1.0, 0.0));
+    testbed.run();
+}


### PR DESCRIPTION
Adds a trait nstc::actor::Actor that represents a thing that can
interact with the virtual world; this is currently implemented only by
the basic BlockBody struct which doesn't do much other than take up
space.

Also adds a simple simulation world using the nphysics_testbed3d crate,
which makes this surprisingly straightforward.